### PR TITLE
implement is_valid check for ODBCConnectionManager

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,9 @@ impl r2d2::ManageConnection for ODBCConnectionManager {
         Ok(ODBCConnection(env.connect_with_connection_string(&self.connection_string)?))
     }
 
-    fn is_valid(&self, _conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
-        //TODO
+    fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
+        let stmt = Statement::with_parent(conn.raw())?;
+        stmt.exec_direct("SELECT 1")?;
         Ok(())
     }
 


### PR DESCRIPTION
- Implement the `is_valid` check for the `ODBCConnectionManager`

This change allows the R2D2 pool to create a new connection if for whatever reason the existing connection is no longer valid.
